### PR TITLE
Fix game crash when `Power.<init>(AbstractCreature, int)` does not exist

### DIFF
--- a/src/main/java/undobutton/patches/UnknownPowersPatches.java
+++ b/src/main/java/undobutton/patches/UnknownPowersPatches.java
@@ -9,6 +9,7 @@ import javassist.CtBehavior;
 import savestate.powers.PowerState;
 import undobutton.UndoButtonMod;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
 public class UnknownPowersPatches {
@@ -16,20 +17,27 @@ public class UnknownPowersPatches {
     public static class forPowerPatch {
         @SpireInsertPatch(locator = Locator.class)
         public static SpireReturn<PowerState> tryToSaveUnknownPower(AbstractPower power) {
-            if (!UndoButtonMod.DEBUG) {
-                return SpireReturn.Return(new PowerState(power) {
-                    @Override
-                    public AbstractPower loadPower(AbstractCreature targetAndSource) {
-                        try {
-                            return power.getClass().getConstructor(AbstractCreature.class, int.class).newInstance(targetAndSource, amount);
-                        } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
-                                 NoSuchMethodException e) {
-                            throw new RuntimeException(e);
-                        }
-                    }
-                });
+            if (UndoButtonMod.DEBUG) {
+                return SpireReturn.Continue();
             }
-            return SpireReturn.Continue();
+            Class<? extends AbstractPower> clazz = power.getClass();
+            Constructor<? extends AbstractPower> constructor;
+            try {
+                constructor = clazz.getConstructor(AbstractCreature.class, int.class);
+            } catch (NoSuchMethodException e) {
+                throw new RuntimeException("Failed to generate default PowerState. " + clazz.getName() + ".<init>(AbstractCreature, int) does not exist.");
+            }
+            return SpireReturn.Return(new PowerState(power) {
+                @Override
+                public AbstractPower loadPower(AbstractCreature targetAndSource) {
+                    UndoButtonMod.logger.debug("Try loading {} with default PowerState, which may cause compatibility issues.", clazz.getName());
+                    try {
+                        return constructor.newInstance(targetAndSource, amount);
+                    } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
         }
 
         public static class Locator extends SpireInsertLocator {


### PR DESCRIPTION
This PR fixed crash of game by the default implemention of `PowerState` provided by this mod. For instance, the [PropBagPower](https://github.com/lf201014/STS_ThMod_MRS/blob/master/src/main/java/ThMod/powers/Marisa/PropBagPower.java#L27) of [Marisa](https://steamcommunity.com/sharedfiles/filedetails/?id=1614104912) mod:
```
ERROR core.CardCrawlGame> Exception caught
java.lang.RuntimeException: java.lang.NoSuchMethodException: ThMod.powers.Marisa.PropBagPower.<init>(com.megacrit.cardcrawl.core.AbstractCreature, int)
	at undobutton.patches.UnknownPowersPatches$forPowerPatch$1.loadPower(UnknownPowersPatches.java:27) ~[undothespire.jar:?]
	at savestate.CreatureState.loadCreature(CreatureState.java:206) ~[?:?]
	at savestate.PlayerState.loadPlayer(PlayerState.java:352) ~[?:?]
	at savestate.SaveState.loadState(SaveState.java:295) ~[SaveStateMod.jar:?]
	at undobutton.GameState.apply(GameState.java:155) ~[undothespire.jar:?]
	at undobutton.UndoButtonController.undo(UndoButtonController.java:94) ~[undothespire.jar:?]
	at undobutton.UndoButtonUI$UndoButton.onClick(UndoButtonUI.java:243) ~[undothespire.jar:?]
	at basemod.ClickableUIElement.update(ClickableUIElement.java:63) ~[BaseMod.jar:?]
	at undobutton.UndoButtonUI$UndoOrRedoButton.update(UndoButtonUI.java:166) ~[undothespire.jar:?]
	at undobutton.UndoButtonUI$UndoButton.update(UndoButtonUI.java:235) ~[undothespire.jar:?]
	at undobutton.UndoButtonUI.update(UndoButtonUI.java:81) ~[undothespire.jar:?]
	at undobutton.UndoButtonMod.receivePostUpdate(UndoButtonMod.java:226) ~[undothespire.jar:?]
	at basemod.BaseMod.publishPostUpdate(BaseMod.java:2437) ~[?:?]
	at basemod.patches.com.megacrit.cardcrawl.core.CardCrawlGame.UpdateHooks$PostUpdateHook.Insert(UpdateHooks.java:52) ~[BaseMod.jar:?]
	at com.megacrit.cardcrawl.core.CardCrawlGame.update(CardCrawlGame.java:897) ~[?:?]
	at com.megacrit.cardcrawl.core.CardCrawlGame.render(CardCrawlGame.java:423) [?:?]
	at com.badlogic.gdx.backends.lwjgl.LwjglApplication.mainLoop(LwjglApplication.java:225) [?:?]
	at com.badlogic.gdx.backends.lwjgl.LwjglApplication$1.run(LwjglApplication.java:126) [?:?]
Caused by: java.lang.NoSuchMethodException: ThMod.powers.Marisa.PropBagPower.<init>(com.megacrit.cardcrawl.core.AbstractCreature, int)
	at java.lang.Class.getConstructor0(Class.java:3082) ~[?:1.8.0_144]
	at java.lang.Class.getConstructor(Class.java:1825) ~[?:1.8.0_144]
	at undobutton.patches.UnknownPowersPatches$forPowerPatch$1.loadPower(UnknownPowersPatches.java:24) ~[undothespire.jar:?]
	... 17 more
```